### PR TITLE
Fix to mouse movement snapping

### DIFF
--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -34,7 +34,7 @@ pub fn orbit_mouse(
 ) {
     let mut rotation = Vec2::ZERO;
     for ev in mouse_evr.read() {
-        rotation = ev.delta;
+        rotation += ev.delta;
     }
 
     let Ok((cam, mut cam_transform)) = cam_q.get_single_mut() else {


### PR DESCRIPTION
Not 100% confident that this fix works the way I think it does, but it seems to resolve an issue with mouse movement snapping at low mouse speeds, as well as a orbit speed cap. This may break existing mouse sensitivities.